### PR TITLE
fix in tensor_data in the from_parts() methods

### DIFF
--- a/polycrystal/utils/tensor_data/mandel_system.py
+++ b/polycrystal/utils/tensor_data/mandel_system.py
@@ -52,7 +52,7 @@ class MandelSystem(BaseSystem):
 
         comps = np.hstack((symm, skew))
         mats = cls.to_matrices(comps)
-        ten = BaseSystem(mats)
+        ten = cls(mats)
         ten.components = comps
 
         return ten

--- a/polycrystal/utils/tensor_data/symmdev_system.py
+++ b/polycrystal/utils/tensor_data/symmdev_system.py
@@ -62,7 +62,7 @@ class SymmDevSystem(BaseSystem):
 
         comps = np.hstack((sph, symmdev, skew))
         mats = cls.to_matrices(comps)
-        ten = BaseSystem(mats)
+        ten = cls(mats)
         ten.components = comps
 
         return ten

--- a/polycrystal/utils/tensor_data/voigt_system.py
+++ b/polycrystal/utils/tensor_data/voigt_system.py
@@ -54,7 +54,7 @@ class VoigtSystem(BaseSystem):
 
         comps = np.hstack((symm, skew))
         mats = cls.to_matrices(comps)
-        ten = BaseSystem(mats)
+        ten = cls(mats)
         ten.components = comps
 
         return ten


### PR DESCRIPTION
This fixes a bug in the from_parts() methods, in which a new instance is instantiated using the base class instead of the `cls` variable.