### PR TITLE
Apply stiffness

### DIFF
--- a/polycrystal/elasticity/single_crystal.py
+++ b/polycrystal/elasticity/single_crystal.py
@@ -206,54 +206,29 @@ class SingleCrystal:
         return np.linalg.inv(self.stiffness)
 
     def apply_stiffness(self, eps, rmat=None):
-        """Compute stress from strain, possibly in rotated framework
+        """Stress tensors from strain tensors in same reference frame
 
+        Parameters
+        ----------
         eps: array(n, 3, 3)
            array of strains, in a common (sample or crystal) reference frame
         rmat: None or array(n, 3, 3)
            array of rotation matrices taking crystal components to sample, or None,
            if the strains are already in crystal components
+
+        Returns
+        -------
+        sig: array(n, 3, 3)
+           array of stresses in same frame as strains
         """
-
-        # Here are some helper functions.
-
-
-        def to_3d(arr):
-            if arr is None:
-                return arr
-
-            if arr.ndim == 2:
-                if arr.shape != (3, 3):
-                    raise RuntimeError("array shape not 3x3")
-                return arr.reshape((1, 3, 3))
-            elif eps.ndim != 3:
-                raise RuntimeError("array shape incrorrect")
-            else:
-                assert arr.ndim == 3
-                return arr
-
-
-        def change_basis(mat, rot):
-            """Change of basis taking M -> R @ M @ R.T
-
-            mat: array(n, 3, 3)
-               array of matrices
-            rot: array(n, 3, 3) or None
-               array of rotation matrices, if reference frame is not crystal
-            """
-            if rot is None:
-                return mat
-            else:
-                return rot @ mat @ rot.transpose((1, 3, 2))
 
 
         # Here is the main calculation.
 
         System = self.system_d[self.output_system]
-        eps_s_mat = to_3d(eps)
-        n = len(eps_s_mat)
+        eps_s_mat = self._to_3d(eps)
 
-        eps_c_mat = change_basis(eps_s_mat, rmat)
+        eps_c_mat = self._change_basis(eps_s_mat, rmat)
 
         eps_c_vec = System(eps_c_mat).symm
         if self.output_system is SYSTEMS.VOIGT_GAMMA:
@@ -264,7 +239,77 @@ class SingleCrystal:
         sig_c_mat = System.from_parts(symm=sig_c_vec.T).matrices
 
         sig_s_mat = sig_c_mat if rmat is None else (
-            change_basis(sig_c_mat, rmat.transpose((1, 3, 2)))
+            self._change_basis(sig_c_mat, rmat.transpose((0, 2, 1)))
         )
 
         return sig_s_mat
+
+    def apply_compliance(self, sig, rmat=None):
+        """Stress tensors from strain tensors in same reference frame
+
+        Parameters
+        ----------
+        sig: array(n, 3, 3)
+           array of stresses, in a common (sample or crystal) reference frame
+        rmat: None or array(n, 3, 3)
+           array of rotation matrices taking crystal components to sample, or None,
+           if the stresses are already in crystal components
+        Returns
+        -------
+        eps: array(n, 3, 3)
+           array of strains in same frame as stresses
+        """
+
+        System = self.system_d[self.output_system]
+        sig_s_mat = self._to_3d(sig)
+
+        sig_c_mat = self._change_basis(sig_s_mat, rmat)
+
+        sig_c_vec = System(sig_c_mat).symm
+
+        eps_c_vec = self.compliance @ sig_c_vec.T
+        if self.output_system is SYSTEMS.VOIGT_GAMMA:
+            eps_c_vec[3:] *= 0.5
+
+        eps_c_mat = System.from_parts(symm=eps_c_vec.T).matrices
+
+        eps_s_mat = eps_c_mat if rmat is None else (
+            self._change_basis(eps_c_mat, rmat.transpose((0, 2, 1)))
+        )
+
+        return eps_s_mat
+
+    @staticmethod
+    def _to_3d(arr):
+        if arr is None:
+            return arr
+
+        if arr.ndim == 2:
+            if arr.shape != (3, 3):
+                raise RuntimeError("array shape not 3x3")
+            return arr.reshape((1, 3, 3))
+        elif arr.ndim != 3:
+            raise RuntimeError("array shape incrorrect")
+        else:
+            assert arr.ndim == 3
+            return arr
+
+    @staticmethod
+    def _change_basis(mat, rot):
+        """Change of basis taking M -> R @ M @ R.T
+
+        mat: array(n, 3, 3)
+           array of matrices
+        rot: array(n, 3, 3) or None
+           array of rotation matrices, if reference frame is not crystal
+        """
+        if rot is None:
+            return mat
+        else:
+            if len(mat) != len(rot):
+                msg = (
+                    "rotation array needs to be the same "
+                    "length as the matrix array"
+                )
+                raise ValueError(msg)
+            return rot @ mat @ rot.transpose((0, 2, 1))

--- a/tests/elasticity/test_single_crystal.py
+++ b/tests/elasticity/test_single_crystal.py
@@ -4,6 +4,8 @@ import pytest
 
 from polycrystal.elasticity.single_crystal import SingleCrystal
 from polycrystal.elasticity.moduli_tools.cubic import Cubic
+from polycrystal.orientations.crystalsymmetry import get_symmetries
+
 
 TOL = 1e-14
 
@@ -21,6 +23,7 @@ class TestSingleCrystal:
 
     @pytest.fixture
     def eps0(cls):
+        """Test strain data"""
         return np.array([
             [1, 2, 3],
             [2, 4, 5],
@@ -155,18 +158,68 @@ class TestSingleCrystal:
         eps3_a = sx.apply_compliance(sig3, rot_90)
         assert np.allclose(eps3, eps3_a)
 
-    def test_apply_cubic(self, eps0, rot_90):
+    def test_apply_cubic(self, eps0):
         """Test cubic stiffness/compliance under rotation"""
+        sym = 'cubic'
         mod = Cubic.from_K_Gd_Gs(3., 2, 5.)
         sx = SingleCrystal('cubic', mod.cij)
 
-        eps3 = np.tile(eps0, (3, 1, 1))
-        sig3 = sx.apply_stiffness(eps3, rot_90)
+        cubsym = get_symmetries(sym)
+        rmats = cubsym.rmats
+        nsym = len(rmats)
 
-        # Stresses should be the same since cubic crystal is invariant under 90-degree
-        # rotations.
-        assert np.allclose(sig3[0], sig3[1])
-        assert np.allclose(sig3[0], sig3[2])
+        eps3 = np.tile(eps0, (nsym, 1, 1))
+        sig3 = sx.apply_stiffness(eps3, rmats)
+
+        # Stresses should be the same since the crystal is invariant under it's
+        # symmetry group.
+
+        assert np.allclose(sig3, np.tile(sig3[0], (nsym, 1, 1)))
+
+        # Verify compliance.
+        eps3_a = sx.apply_compliance(sig3, rmats)
+        assert np.allclose(eps3, eps3_a)
+
+    def test_apply_hexagonal(self, eps0):
+        """Test hexagonal stiffness/compliance under rotation"""
+        # Note that you have to choose moduli to ensure the stiffness is nonsingular.
+        # The choice: [5, 4, 3, 2, 1] apparently led to a singular matrix.
+
+        sym = 'hexagonal'
+        mod = [5.0, 6.2, 3.2, 1.9, 4.2]
+        sx = SingleCrystal(sym, mod)
+        sx.system = "MANDEL"
+
+        hexsym = get_symmetries(sym)
+        rmats = hexsym.rmats
+        nsym = len(rmats)
+
+        eps3 = np.tile(eps0, (nsym, 1, 1))
+        sig3 = sx.apply_stiffness(eps3, rmats)
+
+        # Stresses should be the same since the crystal is invariant under it's
+        # symmetry group.
+
+        assert np.allclose(sig3, np.tile(sig3[0], (nsym, 1, 1)))
+
+        # Verify compliance.
+        eps3_a = sx.apply_compliance(sig3, rmats)
+        print("eps3:\n", eps3[:2], "\nsig3\n", sig3[:2], "\neps3_a\n", eps3_a[:2])
+        assert np.allclose(eps3, eps3_a)
+
+
+    def test_change_of_basis(self, eps0, rot_90):
+        """Test change of basis"""
+        cob = SingleCrystal._change_basis(eps0, None)
+        assert np.allclose(eps0, cob)
+
+        eps3 = np.tile(eps0, (3, 1, 1))
+        cob3 = SingleCrystal._change_basis(eps0, rot_90)
+
+        for i in (0, 1, 2):
+            rot_i = rot_90[i]
+            cob_i = rot_i @ eps0 @ rot_i.T
+            assert np.allclose(cob_i, cob3[i])
 
 
 class TestThermalExpansion:


### PR DESCRIPTION
This adds two methods to the elastic SingleCrystal class. They are `apply_stiffness` and `apply_compliance`.  They both take an array of matrices and optionally an array of change-of-basis matrices, and return an array of matrices. The stiffness operates on strains and returns stresses, while the compliance acts on stress matrices and returns corresponding strain matrices. If the change of  basis matrices are not given, then the inputs are assume to be in the crystal reference frame. If the change of  basis matrices are given, then the strains are assumed to be in a common (sample) reference frame, and they are used to convert back and forth to/from the crystal frame, where the stiffness is applied.

