### PR TITLE
Fix voigt epsilon symmetry

### DIFF
--- a/polycrystal/elasticity/moduli_tools/stiffness_matrix.py
+++ b/polycrystal/elasticity/moduli_tools/stiffness_matrix.py
@@ -84,7 +84,8 @@ class StiffnessMatrix:
             raise ValueError("`system` must be an attribtue of MatrixComponentSystem")
         self._system = system
 
-        self._units = self.ureg.parse_expression(units)
+        # Adding `str(units)` makes it work even when the input is a pint.Unit.
+        self._units = self.ureg.parse_expression(str(units))
         self._matrix = self._fill_cij(cij) * self.units
 
     @staticmethod
@@ -119,9 +120,8 @@ class StiffnessMatrix:
 
     @units.setter
     def units(self, v):
-        uv = self.ureg.parse_expression(v)
-        self._matrix.ito(uv)
-        self._units = uv
+        self._matrix.ito(v)
+        self._units = v
 
     def _rescale_matrix(self, scale):
         self._matrix[:3, 3:] *= scale.up_right

--- a/polycrystal/elasticity/moduli_tools/stiffness_matrix.py
+++ b/polycrystal/elasticity/moduli_tools/stiffness_matrix.py
@@ -88,11 +88,18 @@ class StiffnessMatrix:
         self._units = self.ureg.parse_expression(str(units))
         self._matrix = self._fill_cij(cij) * self.units
 
-    @staticmethod
-    def _fill_cij(cij):
+    def _fill_cij(self, cij):
         mat = np.zeros((6, 6))
         mat[_UT_INDICES] = cij
         mat[_LT_INDICES] = cij[_LT_CIJ]
+
+        # Note that the VOIGT_EPSILON system may not be symmetric as the lower
+        # left 3x3 submatrix is one half the upper right. This corrects for
+        # that.
+        if self.system is MatrixComponentSystem.VOIGT_EPSILON:
+            for i in range(3):
+                for j in range(3,6):
+                    mat[j, i] = 0.5 * mat[i, j]
         return mat
 
     @property

--- a/polycrystal/elasticity/single_crystal.py
+++ b/polycrystal/elasticity/single_crystal.py
@@ -298,7 +298,7 @@ class SingleCrystal:
     def _change_basis(mat, rot):
         """Change of basis taking M -> R @ M @ R.T
 
-        Here the typical use here is converting a matrix in cyrstal components to
+        The typical use here is converting a matrix in cyrstal components to
         one in sample components, where R is the matrix that takes cyrstal components
         of vectors to sample components. In that case:
 

--- a/tests/elasticity/moduli_tools/test_stiffness.py
+++ b/tests/elasticity/moduli_tools/test_stiffness.py
@@ -32,12 +32,17 @@ def check_block(m1, m2, block, factor=1.0):
     return np.allclose(factor * m1[sl], m2[sl])
 
 
+
 class TestStiffness:
 
     @pytest.fixture
-    def all_ones_vg(cls):
+    def upper_indices(cls):
+        return np.triu_indices(6)
+
+    @pytest.fixture
+    def all_ones_vg(cls, upper_indices):
         all_1 = np.ones((6, 6))
-        cij_upper = all_1[ np.triu_indices(6)]
+        cij_upper = all_1[upper_indices]
         units = "MPa"
         return stiffness_matrix.StiffnessMatrix(
             cij_upper, SYSTEMS.VOIGT_GAMMA, units
@@ -78,3 +83,41 @@ class TestStiffness:
         mat_ve_gpa = all_ones_vg.matrix
         all_ones_vg.units = "MPa"
         np.allclose(all_ones_vg.matrix, 1e-3 * mat_ve_gpa)
+
+    def test_instantiation(self, all_ones_vg, upper_indices):
+        """Test instantiation from cij gives same stiffess for all systems"""
+        original_system = SYSTEMS.VOIGT_GAMMA
+
+        # VOIGT_GAMMA
+        check_system = SYSTEMS.VOIGT_GAMMA
+        all_ones_vg.system = check_system
+        print("\nSystem: ", all_ones_vg.system, "\nunits: ", all_ones_vg.units)
+        new_vg = stiffness_matrix.StiffnessMatrix(
+            all_ones_vg.matrix[upper_indices], check_system, all_ones_vg.units,
+        )
+        new_vg.system = original_system
+        all_ones_vg.system = original_system
+        assert np.allclose(all_ones_vg.matrix, new_vg.matrix)
+
+        # MANDEL
+        check_system = SYSTEMS.MANDEL
+        all_ones_vg.system = check_system
+        print("\nSystem: ", all_ones_vg.system, "\nunits: ", all_ones_vg.units)
+        new_vg = stiffness_matrix.StiffnessMatrix(
+            all_ones_vg.matrix[upper_indices], check_system, all_ones_vg.units,
+        )
+        new_vg.system = original_system
+        all_ones_vg.system = original_system
+        assert np.allclose(all_ones_vg.matrix, new_vg.matrix)
+
+        # VOIGT_EPSILON
+        check_system = SYSTEMS.VOIGT_EPSILON
+        all_ones_vg.system = check_system
+        print("\nSystem: ", all_ones_vg.system, "\nunits: ", all_ones_vg.units)
+
+        new_vg = stiffness_matrix.StiffnessMatrix(
+            all_ones_vg.matrix[upper_indices], check_system, all_ones_vg.units,
+        )
+        new_vg.system = original_system
+        all_ones_vg.system = original_system
+        assert np.allclose(all_ones_vg.matrix, new_vg.matrix)

--- a/tests/elasticity/moduli_tools/test_stiffness.py
+++ b/tests/elasticity/moduli_tools/test_stiffness.py
@@ -91,7 +91,6 @@ class TestStiffness:
         # VOIGT_GAMMA
         check_system = SYSTEMS.VOIGT_GAMMA
         all_ones_vg.system = check_system
-        print("\nSystem: ", all_ones_vg.system, "\nunits: ", all_ones_vg.units)
         new_vg = stiffness_matrix.StiffnessMatrix(
             all_ones_vg.matrix[upper_indices], check_system, all_ones_vg.units,
         )
@@ -102,7 +101,6 @@ class TestStiffness:
         # MANDEL
         check_system = SYSTEMS.MANDEL
         all_ones_vg.system = check_system
-        print("\nSystem: ", all_ones_vg.system, "\nunits: ", all_ones_vg.units)
         new_vg = stiffness_matrix.StiffnessMatrix(
             all_ones_vg.matrix[upper_indices], check_system, all_ones_vg.units,
         )
@@ -113,8 +111,6 @@ class TestStiffness:
         # VOIGT_EPSILON
         check_system = SYSTEMS.VOIGT_EPSILON
         all_ones_vg.system = check_system
-        print("\nSystem: ", all_ones_vg.system, "\nunits: ", all_ones_vg.units)
-
         new_vg = stiffness_matrix.StiffnessMatrix(
             all_ones_vg.matrix[upper_indices], check_system, all_ones_vg.units,
         )


### PR DESCRIPTION
This fixes the elastic stiffness matrix instantiated using the `VOIGT_EPSILON` system. The error was that the matrix was symmetrized, but for this system, the upper right 3x3 submatrix is twice the lower left 3x3 submatrix. This was corrected and a test was added to verify this.