### PR TITLE
cleanup

### DIFF
--- a/polycrystal/elasticity/single_crystal.py
+++ b/polycrystal/elasticity/single_crystal.py
@@ -70,7 +70,6 @@ class SingleCrystal:
        coefficient of thermal expansion as a function of a reference temperature
     """
 
-    _MSG_NOT_IMPLEMENTED = "This function is not currently implemented."
     DEFAULT_SYSTEM = SYSTEMS.VOIGT_GAMMA
 
     system_d = {
@@ -297,7 +296,7 @@ class SingleCrystal:
                 raise RuntimeError("array shape not 3x3")
             return arr.reshape((1, 3, 3))
         elif arr.ndim != 3:
-            raise RuntimeError("array shape incrorrect")
+            raise RuntimeError(f"array shape incorrect: got ndim={arr.ndim}")
         else:
             assert arr.ndim == 3
             return arr

--- a/polycrystal/microstructure/multiphase.py
+++ b/polycrystal/microstructure/multiphase.py
@@ -43,9 +43,6 @@ class Multiphase(CgoMicrostructure):
         _msg = "phase array has wrong shape"
         assert (len(self._phase_a) == self.num_grains), _msg
 
-    def __contains__(self, x):
-        return np.ones(len(x), dtype=bool)
-
     @property
     def num_grains(self):
         return len(self.orientation_list)

--- a/polycrystal/microstructure/voxeldata.py
+++ b/polycrystal/microstructure/voxeldata.py
@@ -77,12 +77,9 @@ class VoxelData(CgoMicrostructure):
         return tuple(xdivs)
 
     def grain(self, x):
-        n = len(x)
-        vox = np.zeros((n, 3), dtype=int)
-        for i in range(n):
-            vox[i] = self.voxel_ijk(x[i])
-
-        return self.gids[vox[:,0], vox[:,1], vox[:,2]]
+        dx = x - self.v0
+        vox = np.minimum((dx / self.dv).astype(int), np.array(self.shape) - 1)
+        return self.gids[vox[:, 0], vox[:, 1], vox[:, 2]]
 
     def phase(self, g):
         """Determine grain ID for grain `g`"""

--- a/polycrystal/orientations/crystalsymmetry.py
+++ b/polycrystal/orientations/crystalsymmetry.py
@@ -156,6 +156,11 @@ class _Registry(object):
     @classmethod
     def get(cls, name):
         """return instance associated with name"""
+        if name not in cls.registry:
+            available = ", ".join(sorted(cls.registry.keys()))
+            raise KeyError(
+                f"Unknown symmetry {name!r}. Available: {available}"
+            )
         return cls.registry[name]
     #
     pass  # end class

--- a/polycrystal/orientations/quaternions.py
+++ b/polycrystal/orientations/quaternions.py
@@ -42,24 +42,18 @@ def multiply(q_1, q_2):
     The result is not processed to enforce nonnegativity of the first component
     (as was done in the matlab  OdfPf package).
     """
-    # Reshape q1/q2 if 1D
     if q_1.ndim == 1:
-        q1 = q_1.copy().reshape((1,4))
-    else:
-        q1 = q_1
-
+        q_1 = q_1.copy().reshape((1, 4))
     if q_2.ndim == 1:
-        q2 = q_2.copy().reshape((1,4))
-    else:
-        q2 = q_2
+        q_2 = q_2.copy().reshape((1, 4))
 
-    n1 = len(q1)
-    n2 = len(q2)
+    n1 = len(q_1)
+    n2 = len(q_2)
     n = np.maximum(n1, n2)
-    s1 = q1[:, 0].reshape((n1,1))
-    v1 = q1[:, 1:].reshape((n1,3))
-    s2 = q2[:, 0].reshape((n2,1))
-    v2 = q2[:, 1:].reshape((n2,3))
+    s1 = q_1[:, 0].reshape((n1,1))
+    v1 = q_1[:, 1:].reshape((n1,3))
+    s2 = q_2[:, 0].reshape((n2,1))
+    v2 = q_2[:, 1:].reshape((n2,3))
     qs = s1*s2 - np.sum(v1*v2, axis=1).reshape((n,1))
     qv = (s1*v2) + (s2*v1) + np.cross(v1, v2)
     qprod = np.hstack((qs, qv))
@@ -217,12 +211,12 @@ def random_quats(n, return_matrices=False):
     ----------
     n: int
        the number of orientations to generate
-    return_matrices: bool, defaul = True
+    return_matrices: bool, default = False
        if True return matrices, otherwise quaternions
     """
     q = np.random.standard_normal((n, 4))
     nrm = np.linalg.norm(q, axis=1)
-    if nrm.min() == 0.0:
+    if nrm.min() < 1e-10:
         raise ValueError("generated zero magnitude vector, try again")
     qrand = q/nrm.reshape((n, 1))
 

--- a/polycrystal/utils/tensor_data/base_system.py
+++ b/polycrystal/utils/tensor_data/base_system.py
@@ -65,6 +65,47 @@ class BaseSystem:
         """Set matrices from components"""
         pass
 
+    @classmethod
+    def from_parts(cls, symm=None, skew=None):
+        """Build matrices from parts additively
+
+        Parameters
+        ----------
+        symm: array (n, 6)
+          symmetric part as 6-vector in orthonormal basis
+        skew: array (n, 3)
+          skew part
+        """
+        dim_sym, dim_skw = 6, 3
+
+        len_sym = cls._check_part(symm, dim_sym)
+        len_skw = cls._check_part(skew, dim_skw)
+
+        n = max(len_sym, len_skw)
+        if n == 0:
+            raise ValueError("all parts are None")
+
+        if len_sym == 0:
+            symm = np.zeros((n, dim_sym))
+        else:
+            if len_sym != n:
+                raise ValueError("symm and skew parts must have same length")
+            symm = symm.reshape((n, dim_sym))
+
+        if len_skw == 0:
+            skew = np.zeros((n, dim_skw))
+        else:
+            if len_skw != n:
+                raise ValueError("symm and skew parts must have same length")
+            skew = skew.reshape((n, dim_skw))
+
+        comps = np.hstack((symm, skew))
+        mats = cls.to_matrices(comps)
+        ten = cls(mats)
+        ten.components = comps
+
+        return ten
+
     @staticmethod
     def _check_part(part, dim=None):
         """checks for expected input shape (2D) and length

--- a/polycrystal/utils/tensor_data/mandel_system.py
+++ b/polycrystal/utils/tensor_data/mandel_system.py
@@ -11,53 +11,6 @@ class MandelSystem(BaseSystem):
     _system_name = "Mandel"
 
     @classmethod
-    def from_parts(cls, symm=None, skew=None):
-        """Build matrices from parts additively
-
-        This builds the matrix by specfiying the symmetric and skew parts
-        separately.
-
-        Parameters
-        ----------
-        symm: array (n, 6)
-          symmetric part as 6-vector in Mandel orthonormal basis
-        skew: array (n, 3)
-          skew part
-        """
-        # First, check that everything has compatible shapes.
-        dim_sym, dim_skw = 6, 3
-
-        len_sym = cls._check_part(symm, dim_sym)
-        len_skw = cls._check_part(skew, dim_skw)
-
-        len = max(len_sym, len_skw)
-
-        if len_sym == 0:
-            symm = np.zeros((len, dim_sym))
-        else:
-            if len_sym != len:
-                msg = "symm and skew parts must have same length"
-                raise ValueError(msg)
-            # This handles the 1D array case.
-            symm = symm.reshape((len, dim_sym))
-
-        if len_skw == 0:
-            skew = np.zeros((len, dim_skw))
-        else:
-            if len_skw != len:
-                msg = "symm and skew parts must have same length"
-                raise ValueError(msg)
-            # This handles the 1D array case.
-            skew = skew.reshape((len, dim_skw))
-
-        comps = np.hstack((symm, skew))
-        mats = cls.to_matrices(comps)
-        ten = cls(mats)
-        ten.components = comps
-
-        return ten
-
-    @classmethod
     def to_components(cls, matrices):
         """This sets the `_components` attribute"""
         m = matrices

--- a/polycrystal/utils/tensor_data/voigt_system.py
+++ b/polycrystal/utils/tensor_data/voigt_system.py
@@ -11,55 +11,6 @@ class VoigtSystem(BaseSystem):
     _system_name = "Voigt"
 
     @classmethod
-    def from_parts(cls, symm=None, skew=None):
-        """Build matrices from parts additively
-
-        This builds the matrix by specfiying the symmetric and skew parts
-        separately.
-
-        Parameters
-        ----------
-        symm: array (n, 6)
-          symmetric part as 6-vector in Voigt orthonormal basis
-        skew: array (n, 3)
-          skew part
-        """
-        # First, check that everything has compatible shapes.
-        dim_sym, dim_skw = 6, 3
-
-        len_sym = cls._check_part(symm, dim_sym)
-        len_skw = cls._check_part(skew, dim_skw)
-
-        len = max(len_sym, len_skw)
-        if len == 0:
-            raise ValueError("all parts are None")
-
-        if len_sym == 0:
-            symm = np.zeros((len, dim_sym))
-        else:
-            if len_sym != len:
-                msg = "symm and skew parts must have same length"
-                raise ValueError(msg)
-            # This handles the 1D array case.
-            symm = symm.reshape((len, dim_sym))
-
-        if len_skw == 0:
-            skew = np.zeros((len, dim_skw))
-        else:
-            if len_skw != len:
-                msg = "symm and skew parts must have same length"
-                raise ValueError(msg)
-            # This handles the 1D array case.
-            skew = skew.reshape((len, dim_skw))
-
-        comps = np.hstack((symm, skew))
-        mats = cls.to_matrices(comps)
-        ten = cls(mats)
-        ten.components = comps
-
-        return ten
-
-    @classmethod
     def to_components(cls, matrices):
         """This sets the `_components` attribute"""
         m = matrices

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,13 @@ import sys
 
 from setuptools import setup, find_packages
 
+install_reqs = [
+    'numpy',
+    'scipy',
+    'pytest',
+    'pint',
+    'pyyaml'
+]
 
 setup(
     name = 'polycrystal',
@@ -17,11 +24,5 @@ setup(
         'Topic :: Scientific/Engineering',
         ],
     packages = find_packages(),
+    install_requires = install_reqs,
     )
-install_reqs = [
-    'numpy',
-    'scipy',
-    'pytest',
-    'pint',
-    'pyyaml'
-]


### PR DESCRIPTION
Various fixes and improvements from Claude;

Bug / Correctness

setup.py — Moved install_reqs before setup() and wired it to install_requires=. Dependencies were previously unreachable.
microstructure/multiphase.py — Removed __contains__ entirely. It always returned all-True (never checked containment), and Multiphase is designed to cover all space via phaseID_fun, so the method was both wrong and meaningless.
orientations/quaternions.py — Changed nrm.min() == 0.0 to nrm.min() < 1e-10 in random_quats() to catch near-zero magnitudes that floating-point arithmetic could miss.
Performance

microstructure/voxeldata.py — Replaced the for i in range(n) loop in grain() with a fully vectorized NumPy operation.
Error Messages / Validation

elasticity/single_crystal.py — Fixed typo "incrorrect" → "incorrect" and added the actual ndim to the message.
orientations/crystalsymmetry.py — _Registry.get() now raises a KeyError with the unknown name and a sorted list of valid symmetry names, instead of a bare KeyError.
Code Quality

orientations/quaternions.py — Eliminated q1/q2 locals shadowing parameters q_1/q_2 in multiply(); fixed docstring typo (defaul = True → default = False).
elasticity/single_crystal.py — Removed unused _MSG_NOT_IMPLEMENTED class attribute.
utils/tensor_data/base_system.py — Added from_parts() classmethod here; also fixed the len builtin shadow (renamed to n).
utils/tensor_data/voigt_system.py and mandel_system.py — Removed the duplicate from_parts() implementations (now inherited from BaseSystem). The MandelSystem version was also missing the if n == 0 guard, which is now fixed in the shared implementation. SymmDevSystem keeps its own override due to its different three-part signature.
