### PR TITLE
materials database fix for hexagonal labels

### DIFF
--- a/demo/data/materials.yaml
+++ b/demo/data/materials.yaml
@@ -17,8 +17,8 @@ materials:
     c11 : 154
     c12 : 86.0
     c13 : 67.3
-    c44 : 183
-    c66 : 46.7
+    c33 : 183
+    c44 : 46.7
   reference: >
       Flowers, J. W., K. C. O’Brien, and P. C. McEleney. 1964.
       “Elastic Constants of Alpha-Titanium Single Crystals at 25°C.”

--- a/demo/materials-database.ipynb
+++ b/demo/materials-database.ipynb
@@ -88,8 +88,8 @@
     "    c11 : 154\n",
     "    c12 : 86.0\n",
     "    c13 : 67.3\n",
-    "    c44 : 183\n",
-    "    c66 : 46.7\n",
+    "    c33 : 183\n",
+    "    c44 : 46.7\n",
     "  reference: >\n",
     "      Flowers, J. W., K. C. O’Brien, and P. C. McEleney. 1964.\n",
     "      “Elastic Constants of Alpha-Titanium Single Crystals at 25°C.”\n",
@@ -108,7 +108,7 @@
     {
      "data": {
       "text/plain": [
-       "<polycrystal.elasticity.single_crystal.SingleCrystal at 0x109dac1a0>"
+       "<polycrystal.elasticity.single_crystal.SingleCrystal at 0x1129b01a0>"
       ]
      },
      "execution_count": 4,
@@ -200,6 +200,14 @@
    "source": [
     "One final note. The above entries are for materials with istotropic, cubic or hexagonal symmetries, and each symmetry has a subset of the `cij` to enter. For a monoclinic material, with no symmetries (other than identity), you use the `cij` key with value of the 21 independent moduli in order left to right, then top to bottom for the upper triangle of the stiffness matrix.  Symmetries other than istotropic, cubic and hexagonal have not been implemented, but can entered by treating them a monoclinic."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50d4dbb6-d44e-4d8c-95c1-fdab7bd9f8c9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/polycrystal/elasticity/moduli_tools/cubic.py
+++ b/polycrystal/elasticity/moduli_tools/cubic.py
@@ -21,6 +21,8 @@ class Cubic(BaseModuli):
        elastic modulus coefficients
     system: Enum
        MatrixComponentSystem
+    units: str
+       units for the stress
     """
     def __init__(self, c11, c12, c44, system, units):
         self.c11 = c11

--- a/polycrystal/elasticity/moduli_tools/hexagonal.py
+++ b/polycrystal/elasticity/moduli_tools/hexagonal.py
@@ -11,7 +11,7 @@ class Hexagonal(BaseModuli):
 
     Parameters
     ----------
-    c11, c12: float
+    c11, c12, c13, c33, c44: float
        elastic modulus coefficients
     system: Enum
        MatrixComponentSystem attribute

--- a/polycrystal/elasticity/moduli_tools/isotropic.py
+++ b/polycrystal/elasticity/moduli_tools/isotropic.py
@@ -16,6 +16,8 @@ class Isotropic(BaseModuli):
        elastic modulus coefficients
     system: Enum
        MatrixComponentSystem attribute
+    units: str
+       units for the stress
     """
 
     def __init__(self, c11, c12, system, units):

--- a/polycrystal/elasticity/moduli_tools/triclinic.py
+++ b/polycrystal/elasticity/moduli_tools/triclinic.py
@@ -15,6 +15,8 @@ class Triclinic(BaseModuli):
        elastic modulus coefficients
     system: Enum
        MatrixComponentSystem attribute
+    units: str
+       units for the stress
     """
 
     def __init__(self, cij, system, units):

--- a/polycrystal/materials_database/linear_elasticity.py
+++ b/polycrystal/materials_database/linear_elasticity.py
@@ -8,7 +8,7 @@ from polycrystal.elasticity.moduli_tools.isotropic import Isotropic
 from .base_loader import BaseLoader
 
 
-C11, C12, C13, C44, C66 = "c11", "c12", "c13", "c44", "c66"
+C11, C12, C13, C33, C44 = "c11", "c12", "c13", "c33", "c44"
 E, NU = "E", "nu"
 
 
@@ -77,7 +77,7 @@ class LinearElasticMaterial(BaseLoader):
         elif symm2use == "cubic":
             cij = [mod[c] for c in (C11, C12, C44)]
         elif symm2use == "hexagonal":
-            cij = [mod[c] for c in (C11, C12, C13, C44, C66)]
+            cij = [mod[c] for c in (C11, C12, C13, C33, C44)]
 
         return cij
 

--- a/tests/materials_database/test_le.yaml
+++ b/tests/materials_database/test_le.yaml
@@ -30,8 +30,8 @@ materials:
     c11 : 11.0
     c12 : 12.0
     c13 : 13.0
-    c44 : 44.0
-    c66 : 66.0
+    c33 : 44.0
+    c44 : 66.0
   reference: hex-mat-ref
 
 - name     : tet-mat


### PR DESCRIPTION
This fixes the YAML labels for hexagonal moduli. The YAML entries were for C44 and C66, but the data values actually corresponded to C33 and C44. This is corrected in the database, the demo and the tests.

